### PR TITLE
Ignore Users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Prevent users from having a conversation with AWS Lex.
+  - Added by [Ben Hanzl](https://github.com/benhanzl) in Pull Request [#6](https://github.com/benhanzl/hubot-lex/pull/6).
 
 ## [0.1.0] - 2017-11-22
 ### Added

--- a/src/hubot-lex.js
+++ b/src/hubot-lex.js
@@ -6,6 +6,8 @@
 // Configuration:
 //   LEX_API_URL - Required. The URL for the AWS Lex API.
 //   LEX_API_KEY - Optional. The x-api-key used for authenticating.
+//   LEX_IGNORE_USER_IDS - Optional. A comman-separated string of HipChat user
+//     IDs to ignore.
 //   LEX_START_REGEXP - Optional. A RegExp for starting a conversation.
 //
 // Commands:
@@ -24,6 +26,11 @@ module.exports = (robot) => {
   const apiKey = process.env.LEX_API_KEY;
   const defaultErrorMessage = "Unable to communicate with AWS Lex.";
 
+  let ignoreUserIds = [];
+  if (process.env.LEX_IGNORE_USER_IDS) {
+    ignoreUserIds = process.env.LEX_IGNORE_USER_IDS.toLowerCase().split(",");
+  }
+
   let startRegExp = /lex/i;
 
   if (!apiURL) {
@@ -40,6 +47,11 @@ module.exports = (robot) => {
   }
 
   robot.respond(/.+/i, (match) => {
+    if (ignoreUserIds.includes(match.envelope.user.id.toLowerCase())) {
+      robot.logger.info(`hubot-lex: Ignoring user ${match.envelope.user.id}`);
+      return;
+    }
+
     const conversationKey = `conversation-${match.envelope.room}`;
     const lastConversation = robot.brain.get(conversationKey);
 

--- a/src/hubot-lex.js
+++ b/src/hubot-lex.js
@@ -47,8 +47,9 @@ module.exports = (robot) => {
   }
 
   robot.respond(/.+/i, (match) => {
-    if (ignoreUserIds.includes(match.envelope.user.id.toLowerCase())) {
-      robot.logger.info(`hubot-lex: Ignoring user ${match.envelope.user.id}`);
+    const userId = match.envelope.user.id;
+    if (_.includes(ignoreUserIds, userId.toLowerCase())) {
+      robot.logger.info(`hubot-lex: Ignoring user ${userId}`);
       return;
     }
 

--- a/test/hubot-lex-test.js
+++ b/test/hubot-lex-test.js
@@ -14,11 +14,11 @@ const Hubot = require("hubot");
 const Robot = Hubot.Robot;
 const TextMessage = Hubot.TextMessage;
 
-const startRobot = () => {
+function startRobot() {
   const robot = new Robot(null, "mock-adapter-v3", false, "Hubot");
   robot.loadFile(path.resolve("src/"), "hubot-lex.js");
 
-  robot.adapter.on("connected", () => {
+  robot.adapter.on("connected", function() {
     robot.brain.userForId("1", {
       name: "john",
       real_name: "John Doe",
@@ -37,26 +37,26 @@ const startRobot = () => {
   return robot;
 };
 
-beforeEach(() => {
+beforeEach(function() {
   nock.disableNetConnect();
 });
 
-afterEach(() => {
+afterEach(function() {
   nock.cleanAll();
   nock.enableNetConnect();
 });
 
-describe("require('hubot-lex')", () => {
-  it("exports a function", () => {
+describe("require('hubot-lex')", function() {
+  it("exports a function", function() {
     expect(require("../index")).to.be.a("Function");
   });
 });
 
-describe("hubot-lex (without environment variables)", () => {
+describe("hubot-lex (without environment variables)", function() {
   let robot;
   let user;
 
-  afterEach(() => {
+  afterEach(function() {
     delete process.env.LEX_API_URL;
     delete process.env.LEX_API_KEY;
     delete process.env.LEX_START_REGEXP;
@@ -64,7 +64,7 @@ describe("hubot-lex (without environment variables)", () => {
     robot.shutdown();
   });
 
-  it("doesn't respond if LEX_API_URL not specified", (done) => {
+  it("doesn't respond if LEX_API_URL not specified", function(done) {
     robot = startRobot();
     user = robot.brain.userForName("john");
 
@@ -77,12 +77,12 @@ describe("hubot-lex (without environment variables)", () => {
   });
 });
 
-describe("hubot-lex", () => {
+describe("hubot-lex", function() {
   let lex;
   let robot;
   let user;
 
-  beforeEach(() => {
+  beforeEach(function() {
     const lexURL = "http://lex-api-gateway.test.com";
     lex = nock(lexURL);
 
@@ -93,19 +93,19 @@ describe("hubot-lex", () => {
     user = robot.brain.userForName("john");
   });
 
-  afterEach(() => {
+  afterEach(function() {
     delete process.env.LEX_API_URL;
     delete process.env.LEX_START_REGEXP;
 
     robot.shutdown();
   });
 
-  it("sends text to Lex if it matches the start regexp", (done) => {
+  it("sends text to Lex if it matches the start regexp", function(done) {
     lex.post("/messages").reply(200, {
       message: "hello!"
     });
 
-    robot.adapter.on("reply", (envelope, strings) => {
+    robot.adapter.on("reply", function(envelope, strings) {
       expect(strings[0]).to.eql("hello!");
       done();
     });
@@ -113,7 +113,7 @@ describe("hubot-lex", () => {
     robot.adapter.receive(new TextMessage(user, "@hubot lex hello"));
   });
 
-  it("ignores text if it doesn't match the start regexp", (done) => {
+  it("ignores text if it doesn't match the start regexp", function(done) {
     const request = sinon.spy(lex, "post");
 
     robot.adapter.receive(new TextMessage(user, "@hubot hello"));
@@ -122,14 +122,14 @@ describe("hubot-lex", () => {
     done();
   });
 
-  it("doesn't send @hubot in the text to Lex", (done) => {
-    const request = lex.post("/messages", (body) => {
+  it("doesn't send @hubot in the text to Lex", function(done) {
+    const request = lex.post("/messages", function(body) {
       return body.text === "lex hello";
     }).reply(200, {
       message: "hello!"
     });
 
-    robot.adapter.on("reply", (envelope, strings) => {
+    robot.adapter.on("reply", function(envelope, strings) {
       expect(request.isDone());
       expect(strings[0]).to.eql("hello!");
       done();
@@ -138,10 +138,10 @@ describe("hubot-lex", () => {
     robot.adapter.receive(new TextMessage(user, "@hubot lex hello"));
   });
 
-  it("replies with error message if Lex returns an error", (done) => {
+  it("replies with error message if Lex returns an error", function(done) {
     lex.post("/messages").reply(500, {});
 
-    robot.adapter.on("reply", (envelope, strings) => {
+    robot.adapter.on("reply", function(envelope, strings) {
       expect(strings[0]).to.eql("Unable to communicate with AWS Lex.");
       done();
     });
@@ -149,7 +149,7 @@ describe("hubot-lex", () => {
     robot.adapter.receive(new TextMessage(user, "@hubot lex hello"));
   });
 
-  it("starts a conversation if Lex responds with ConfirmIntent", (done) => {
+  it("starts a conversation if Lex responds with ConfirmIntent", function(done) {
     lex.post("/messages").reply(200, {
       dialogState: "ConfirmIntent",
       message: "Are you sure?"
@@ -158,7 +158,7 @@ describe("hubot-lex", () => {
     const conversationKey = `conversation-${user.room}`;
     expect(robot.brain.get(conversationKey)).to.be.null;
 
-    robot.adapter.on("reply", (envelope, strings) => {
+    robot.adapter.on("reply", function(envelope, strings) {
       expect(strings[0]).to.eql("Are you sure?");
       expect(robot.brain.get(conversationKey)).to.not.be.null;
       done();
@@ -167,7 +167,7 @@ describe("hubot-lex", () => {
     robot.adapter.receive(new TextMessage(user, "@hubot lex start conversation"));
   });
 
-  it("sends message (that doesn't match start regexp) to Lex if conversation started", (done) => {
+  it("sends message (that doesn't match start regexp) to Lex if conversation started", function(done) {
     const conversationKey = `conversation-${user.room}`;
     robot.brain.set(conversationKey, Date.now());
 
@@ -175,7 +175,7 @@ describe("hubot-lex", () => {
       message: "hello!"
     });
 
-    robot.adapter.on("reply", (envelope, strings) => {
+    robot.adapter.on("reply", function(envelope, strings) {
       expect(strings[0]).to.eql("hello!");
       done();
     });
@@ -183,7 +183,7 @@ describe("hubot-lex", () => {
     robot.adapter.receive(new TextMessage(user, "@hubot hello"));
   });
 
-  it("stops a conversation if Lex responds with ElicitIntent", (done) => {
+  it("stops a conversation if Lex responds with ElicitIntent", function(done) {
     lex.post("/messages").reply(200, {
       dialogState: "Fulfilled",
       message: "Your request has been completed."
@@ -192,7 +192,7 @@ describe("hubot-lex", () => {
     const conversationKey = `conversation-${user.room}`;
     robot.brain.set(conversationKey, Date.now());
 
-    robot.adapter.on("reply", (envelope, strings) => {
+    robot.adapter.on("reply", function(envelope, strings) {
       expect(strings[0]).to.eql("Your request has been completed.");
       expect(robot.brain.get(conversationKey)).to.be.null;
       done();
@@ -202,14 +202,14 @@ describe("hubot-lex", () => {
   });
 });
 
-describe("hubot-lex (with ignored users)", () => {
+describe("hubot-lex (with ignored users)", function() {
   let lex;
   let robot;
 
   let ignoreUser;
   let user;
 
-  beforeEach(() => {
+  beforeEach(function() {
     const lexURL = "http://lex-api-gateway.test.com";
     lex = nock(lexURL);
 
@@ -221,14 +221,14 @@ describe("hubot-lex (with ignored users)", () => {
     user = robot.brain.userForName("john");
   });
 
-  afterEach(() => {
+  afterEach(function() {
     delete process.env.LEX_API_URL;
     delete process.env.LEX_IGNORE_USER_IDS;
 
     robot.shutdown();
   });
 
-  it("doesn't send messages to Lex if the user is ingored", (done) => {
+  it("doesn't send messages to Lex if the user is ingored", function(done) {
     const request = sinon.spy(lex, "post");
 
     robot.adapter.receive(new TextMessage(ignoreUser, "@hubot lex hello"));
@@ -237,12 +237,12 @@ describe("hubot-lex (with ignored users)", () => {
     done();
   });
 
-  it("sends messages to Lex if the user is not ingored", (done) => {
+  it("sends messages to Lex if the user is not ingored", function(done) {
     lex.post("/messages").reply(200, {
       message: "hello!"
     });
 
-    robot.adapter.on("reply", (envelope, strings) => {
+    robot.adapter.on("reply", function(envelope, strings) {
       expect(strings[0]).to.eql("hello!");
       done();
     });


### PR DESCRIPTION
Fixes #5.

# Proposed Changes

A new, optional, environment variable was introduced called `LEX_IGNORE_USER_IDS`. It's value should be a comma-separated list of user IDs to ignore.

Example: `1234,ignoreme,4321,ignoremetoo`

If the ID of the user sending the message matches an ignored user ID, the message is not forwarded to Lex.